### PR TITLE
【サーバサイド】商品詳細表示 1/4 商品データをDBから読み取る

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -188,6 +189,11 @@ GEM
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.2)
     rack (2.0.7)
@@ -312,6 +318,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
+  pry-rails
   puma (~> 3.12)
   rails (~> 5.2.3)
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -1,7 +1,3 @@
-// Place all the styles related to the items controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
-
 
 .wrapper {
   background-color: #f5f5f5;
@@ -34,15 +30,15 @@
 
       &__photo {
         position: relative;
-        background-color: #f5f5f5;
-
+        
         img {
           padding: 0;
           margin: 0;
           display: block;
         }
-
+        
         &__sub-image {
+          background-color: #f5f5f5;
           width: 300px;
           display: flex;
           flex-wrap: wrap;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,5 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
     @image = Image.includes(:item)
-    # binding.pry
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,8 +3,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    binding.pry
     @item = Item.find(params[:id])
     @image = Image.includes(:item)
+    # binding.pry
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,10 @@
 class ItemsController < ApplicationController
   def index
   end
+
+  def show
+    binding.pry
+    @item = Item.find(params[:id])
+    @image = Image.includes(:item)
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,2 @@
+class Image < ApplicationRecord
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,3 @@
 class Image < ApplicationRecord
+  belongs_to :item
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,2 @@
+class Item < ApplicationRecord
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,3 @@
 class Item < ApplicationRecord
+  has_many :images
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,25 +1,21 @@
 .wrapper
   .content
     .content__top
-      メンズ　ビジネスシューズ　ブラック25cm
+      = @item.name
     .content__item-data
       .content__item-data__photo
         .content__item-data__photo__main-image
-          = image_tag 'show-item01.jpg', size: "300x300", alt: "ユーザー投稿写真"
+          = image_tag @image.first.url, size: "300x300", alt: "ユーザー投稿写真"
         .content__item-data__photo__sub-image
-          = image_tag 'show-item01.jpg', size: "60x60", alt: "ユーザー投稿写真"
-          = image_tag 'show-item02.jpg', size: "60x60", alt: "ユーザー投稿写真"
-          = image_tag 'show-item03.jpg', size: "60x60", alt: "ユーザー投稿写真"
-          = image_tag 'show-item04.jpg', size: "60x60", alt: "ユーザー投稿写真"
-          = image_tag 'show-item05.jpg', size: "60x60", alt: "ユーザー投稿写真"
-          = image_tag 'show-item06.jpg', size: "60x60", alt: "ユーザー投稿写真"
+          - @image.each do |image|
+            = image_tag image.url, size: "60x60", alt: "ユーザー投稿写真"
       .content__item-data__table
         %table
           %tr.content__item-data__table__user-line
             %td.content__item-data__table__td= "出品者"
             %td
               .content__item-data__table__user-line__user-name
-                = link_to "のんたん", ""
+                = link_to @item.user_id, ""
               .content__item-data__table__user-line__evaluate
                 .content__item-data__table__user-line__evaluate__good
                   = icon 'fas', 'laugh', class: 'icon'
@@ -45,28 +41,28 @@
                   = "ドレス/ビジネス"
           %tr.content__item-data__table__brand
             %td.content__item-data__table__td= "ブランド"
-            %td= ""
+            %td= @item.try(:brand)
           %tr.content__item-data__table__size
             %td.content__item-data__table__td= "商品のサイズ"
-            %td= "25cm"
+            %td= @item.try(:size)
           %tr.content__item-data__table__status
             %td.content__item-data__table__td= "商品の状態"
-            %td= "新品、未使用"
+            %td= @item.grade
           %tr.content__item-data__table__cost
             %td.content__item-data__table__td= "配送料の負担"
-            %td= "送料込み(出品者負担)"
+            %td= @item.transfer_fee
           %tr.content__item-data__table__type
             %td.content__item-data__table__td= "配送の方法"
-            %td= "ゆうゆうメルカリ便"
+            %td= @item.delivery_type
           %tr.content__item-data__table__area
             %td.content__item-data__table__td= "配送元地域"
-            %td= link_to "奈良県", ""
+            %td= link_to @item.from_delivery_area, ""
           %tr.content__item-data__table__day
             %td.content__item-data__table__td= "発送日の目安"
-            %td= "2~3日で発送"
+            %td= @item.delivery_date
     .content__price
       .content__price__price
-        = "¥5,000"
+        = "¥#{@item.price.to_s(:delimited)}"
         %span.content__price__tax
           = "(税込) "
         %span.content__price__fee
@@ -76,12 +72,7 @@
     .content__note
       この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。
     .content__item-description
-      日本製　本革　
-      新品未使用
-      抗菌、消臭加工
-      25cm
-      %br
-      写真5、6枚目のブラックの靴のみ商品です。
+      = @item.describe
     .content__button-area
       .content__button-area__box
         %label.content__button-area__box__good

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,12 +8,11 @@ Bundler.require(*Rails.groups)
 
 module FreemarketSample64d
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
   end
 end

--- a/db/migrate/20191210093144_create_items.rb
+++ b/db/migrate/20191210093144_create_items.rb
@@ -1,0 +1,22 @@
+class CreateItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :items do |t|
+      t.string  :status,              null: false #出品ステータス
+      t.string  :name,                null: false #商品名
+      t.string  :from_delivery_area,  null: false #配送元地域
+      t.string  :to_delivery_area                 #配送先地域
+      t.integer :price,               null: false #価格
+      t.string  :delivery_date,       null: false #発送日の目安
+      t.string  :size                             #服のサイズ
+      t.string  :grade,               null: false #商品の状態
+      t.string :transfer_fee,         null: false #配送料の負担
+      t.string  :delivery_type,       null: false #発送の方法
+      t.text    :describe,            null: false #商品の説明
+      t.integer :buyer_id                         #購入者ID
+      t.integer :user_id,             null: false #売却者ID
+      t.integer :brand_id                         #ブランドID
+      t.integer :category_id,         null: false #カテゴリーID
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191210101949_create_images.rb
+++ b/db/migrate/20191210101949_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string  :url,     null: false #商品画像URL
+      t.integer :item_id, null: false #商品ID
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_120123) do
+ActiveRecord::Schema.define(version: 2019_12_10_101949) do
+
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "url", null: false
+    t.integer "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "status", null: false
+    t.string "name", null: false
+    t.string "from_delivery_area", null: false
+    t.string "to_delivery_area"
+    t.integer "price", null: false
+    t.string "delivery_date", null: false
+    t.string "size"
+    t.string "grade", null: false
+    t.string "transfer_fee", null: false
+    t.string "delivery_type", null: false
+    t.text "describe", null: false
+    t.integer "buyer_id"
+    t.integer "user_id", null: false
+    t.integer "brand_id"
+    t.integer "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false


### PR DESCRIPTION
# What
- 商品、商品画像のモデル、DB作成
- 商品DBから商品データを反映
(ユーザー関連のデータはユーザー登録ができてから実装する、現時点はuser_idを表示)
# Why
商品詳細ページの商品データをDBから読み取れるようにする
- 優先順位を付けたためコメント機能・関連商品は除外する