### PR TITLE
【マークアップ】商品購入確認ページ 1/2 購入ページのみ

### DIFF
--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -398,7 +398,7 @@
             justify-content: space-between;
           }
 
-          &__adress {
+          &__address {
             white-space: pre-wrap;
           }
         }

--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -5,6 +5,7 @@
   height: 100%;
   font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
 
+  // =商品詳細ページここから============================
   a {
     text-decoration: none;
     color: #0099e8;
@@ -274,4 +275,158 @@
     margin: 0 auto;
     padding: 16px 0;
   }
+  // =商品詳細ページここまで============================
+
+  // =商品購入ページここから============================
+  .buy-content {
+    background-color: #f5f5f5;
+    width: 700px;
+    height: 765px;
+    margin: 100px auto 0;
+
+    .buy-area {
+      background-color: #fff;
+      height: 100%;
+      width: 100%;
+
+      &__title {
+        font-size: 22px;
+        text-align: center;
+        padding: 32px;
+      }
+
+      &__item-area {
+        padding: 32px 16px;
+
+        &__inner {
+          margin: 0 auto;
+          width: 340px;
+          height: 80px;
+          display: flex;
+
+          &__describe-area {
+            margin-left: 16px;
+
+            &__title {
+              font-size: 14px;
+              padding-bottom: 8px;
+            }
+
+            &__price-area {
+              display: flex;
+
+              &__price {
+                font-size: 15px;
+                font-weight: bold;
+              }
+
+              &__tax {
+                font-size: 12px;
+                font-weight: bold;
+              }
+            }
+          }
+        }
+      }
+      &__buy-form {
+        width: 340px;
+        margin: 0 auto;
+        padding: 32px 16px 48px;
+
+        &__price-area {
+          width: 100%;
+          height: 30px;
+          display: flex;
+          justify-content: space-between;
+
+          &__label {
+            font-size: 18px;
+            font-weight: bold;
+            padding-top: 6px;
+          }
+
+          &__price {
+            font-size: 30px;
+          }
+        }
+
+        &__point-area {
+          height: 14px;
+          padding: 24px 0 32px;
+
+          #buy_form_point {
+            transform: scale(1.5);
+            display: inline-block;
+          }
+
+          &__point {
+            font-size: 14px;
+            padding-left: 10px;
+          }
+        }
+
+        &__chash-area {
+          padding: 32px 0;
+
+          &__title {
+            font-size: 14px;
+            font-weight: bold;
+          }
+
+          &__card-area {
+            font-size: 14px;
+
+            a {
+              display: flex;
+
+              .fa-plus-circle {
+                padding-top: 2px;
+              }
+            }
+
+            &__notice {
+              margin-left: 5px;
+            }
+
+          }
+        }
+        &__deribary-area {
+          font-size: 14px;
+
+          &__title-area {
+            display: flex;
+            justify-content: space-between;
+          }
+
+          &__adress {
+            white-space: pre-wrap;
+          }
+        }
+        &__submit {
+          padding-top: 32px;
+
+          &__btn {
+            background: none;
+            border: none;
+            outline: none;
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            appearance: none;
+            width: 100%;
+            height: 50px;
+            color: #fff;
+            font-size: 14px;
+            font-weight: bold;
+            // 購入できない場合
+            cursor: not-allowed;
+            background-color: #888;
+            // 購入できる場合
+            // cursor: pointer;
+            // background-color: #ea352d;
+          }
+        }
+      }
+    }
+  }
+  // =商品購入ページここまで============================
 }

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -1,0 +1,46 @@
+.wrapper
+  .buy-content
+    .buy-area
+      .buy-area__title
+        購入内容の確認
+      .buy-area__item-area
+        .buy-area__item-area__inner
+          .buy-area__item-area__inner__image
+            = image_tag 'show-item01.jpg', size: "80x80", alt: "ユーザー投稿写真"
+          .buy-area__item-area__inner__describe-area
+            .buy-area__item-area__inner__describe-area__title
+              = "高コスパゲーミングpc　Rx480　8GB (大抵のゲームは快適動作可能)"
+            .buy-area__item-area__inner__describe-area__price-area
+              .buy-area__item-area__inner__describe-area__price-area__price
+                = "¥46,000"
+              .buy-area__item-area__inner__describe-area__price-area__tax
+                （税込）送料込み
+      .buy-area__buy-form
+        .buy-area__buy-form__price-area
+          .buy-area__buy-form__price-area__label
+            支払い金額
+          .buy-area__buy-form__price-area__price
+            = "¥46,000"
+        -# ポイント機能は後回しにする
+        -# .buy-area__buy-form__point-area
+        -#   = check_box_tag :buy_form_point
+        -#   = label_tag :buy_form_point, "ポイントを使用 (所持ポイント: P0)", class: "buy-area__buy-form__point-area__point"
+        .buy-area__buy-form__chash-area
+          .buy-area__buy-form__chash-area__title
+            支払い方法
+          .buy-area__buy-form__chash-area__card-area
+            = link_to  "" do
+              = icon 'fas', 'plus-circle', class: 'buy-area__buy-form__chash-area__card-area__icon'
+              .buy-area__buy-form__chash-area__card-area__notice= "登録してください"
+        .buy-area__buy-form__deribary-area
+          .buy-area__buy-form__deribary-area__title-area
+            .buy-area__buy-form__deribary-area__title-area__title
+              配送先
+            .buy-area__buy-form__deribary-area__title-area__change
+              = link_to "変更する", ""
+          .buy-area__buy-form__deribary-area__adress
+            〒123-4567
+            北海道 札幌市 123-abc
+            山田 太郎
+        .buy-area__buy-form__submit
+          %input{type: "submit", value: "購入する", class: "buy-area__buy-form__submit__btn"}

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -38,7 +38,7 @@
               配送先
             .buy-area__buy-form__deribary-area__title-area__change
               = link_to "変更する", ""
-          .buy-area__buy-form__deribary-area__adress
+          .buy-area__buy-form__deribary-area__address
             〒123-4567
             北海道 札幌市 123-abc
             山田 太郎

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,9 @@ Rails.application.routes.draw do
       get 'logout'
     end
   end
-  resources :items, only: :show
+  resources :items, only: :show do
+    member do
+      get 'buy'
+    end
+  end
 end


### PR DESCRIPTION
 # What
- 商品購入画面のマークアップ
- ルーティングはcollectionを使用してurlにitemのidを使用する
- 商品データは仮。サーバーサイド実装時にDBを参照する
# Why
商品の購入確認ページを作成する
- 優先順位を付けたためリンク先は除外する