### PR TITLE
add address validation

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,21 @@
 class Address < ApplicationRecord
+
   belongs_to :user
+  with_options presence: true, format: {with: /\A[^ -~｡-ﾟ]+\z/, message: "全角のみで入力して下さい"} do
+    validates :last_name
+    validates :first_name
+  end
+
+  with_options presence: true, format: {with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい"} do
+    validates :last_name_kana
+    validates :first_name_kana
+  end
+
+  with_options presence: true do
+    validates :post_number
+    validates :prefecture
+    validates :municipality
+    validates :block
+  end
+
 end


### PR DESCRIPTION
# what
アドレス登録のバリデーションを記述する。
# why
めちゃくちゃな情報が登録されないようにするため

バリデーション の内容
名前：空はダメ、全角じゃないとダメ
名前カナ：空はダメ、全角でカタカナじゃないとダメ
郵便番号、都道府県、市区町村、番地：空はダメ