### PR TITLE
add-カテゴリのselectボックスを実装

### DIFF
--- a/app/assets/javascripts/new_item_category.js
+++ b/app/assets/javascripts/new_item_category.js
@@ -1,0 +1,49 @@
+$(function(){
+
+  // 親カテゴリーを選択した際に、子カテゴリーを表示させる
+  $(document).on('change', '#category_parent', function(){
+    var parent_id = $(this).val()
+    $('#category_children').parent().removeClass('display_none')
+    $('#category_grandchild').parent().addClass('display_none')
+    $.ajax({
+      type: 'GET',
+      url: '/set_children_category',
+      data: {parent_id: parent_id},
+      dataType: 'json'
+    })
+    .done(function(categories){
+      $("#category_children").empty()
+      $("#category_children").append('<option value="" selected>---</option>')
+      $.each(categories, function(i, category){
+        var children_category = `<option value="${category.id}">${category.name}</option>`
+        $("#category_children").append(children_category)
+      })
+    })
+    .fail(function(){
+      alert('error')
+    })
+  })
+
+  // 子カテゴリーを選択した際に、孫カテゴリーを表示させる
+  $(document).on('change', '#category_children', function(){
+    var children_id = $(this).val()
+    $('#category_grandchildren').parent().removeClass('display_none')
+    $.ajax({
+      type: 'GET',
+      url: '/set_grandchild_category',
+      data: {children_id: children_id},
+      dataType: 'json'
+    })
+    .done(function(categories){
+      $("#category_grandchildren").empty()
+      $("#category_grandchildren").append('<option value="" selected>---</option>')
+      $.each(categories, function(i, category){
+        var grandchild_category = `<option value="${category.id}" name="category">${category.name}</option>`
+        $("#category_grandchildren").append(grandchild_category)
+      })
+    })
+    .fail(function(){
+      alert('error')
+    })
+  })
+})

--- a/app/assets/javascripts/new_item_category.js
+++ b/app/assets/javascripts/new_item_category.js
@@ -7,7 +7,7 @@ $(function(){
     $('#category_grandchild').parent().addClass('display_none')
     $.ajax({
       type: 'GET',
-      url: '/set_children_category',
+      url: '/categories/set_children_category',
       data: {parent_id: parent_id},
       dataType: 'json'
     })
@@ -30,7 +30,7 @@ $(function(){
     $('#category_grandchildren').parent().removeClass('display_none')
     $.ajax({
       type: 'GET',
-      url: '/set_grandchild_category',
+      url: '/categories/set_grandchild_category',
       data: {children_id: children_id},
       dataType: 'json'
     })

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,4 +28,6 @@ body{
   font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
 }
 
-
+.display_none {
+  display: none;
+}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,11 @@
+class CategoriesController < ApplicationController
+
+  def set_children_category
+    @category = Category.where(ancestry: params[:parent_id].to_i)
+  end
+
+  def set_grandchild_category
+    @category = Category.where(ancestry: params[:children_id].to_i)
+  end
+
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,8 @@ class ItemsController < ApplicationController
   end
 
   def new
-    @item=Item.new
+    @item = Item.new
+    @parent_category = Category.where(ancestry: nil)
   end
 
   def create

--- a/app/views/categories/set_children_category.json.jbuilder
+++ b/app/views/categories/set_children_category.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category do |category|
+  json.name category.name
+  json.id   category.id
+end

--- a/app/views/categories/set_grandchild_category.json.jbuilder
+++ b/app/views/categories/set_grandchild_category.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category do |category|
+  json.name category.name
+  json.id   category.id
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -52,12 +52,10 @@
               .select-wrap
                 %i.fa.fa-angle-down
                 //TODO:カテゴリーテーブル実装後に、カテゴリをselectで表示する機能を追加（以下の1行を修正する）
-                %select.k_ir_section__inner--form3-right-select-category#category_parent
-              //TODO:javascriptで「$(document).on('change', '#category_parent', function(){・・・」のようにクラスを削除・追加する
+                = f.collection_select :category, @parent_category, :id, :name, {prompt: '---'}, class: "k_ir_section__inner--form3-right-select-category", id: "category_parent"
               .display_none.select-wrap
                 %i.fa.fa-angle-down
                 %select.k_ir_section__inner--form3-right-select-category#category_children
-              //TODO:javascriptで「$(document).on('change', '#category_children', function(){・・・」のようにクラスを削除・追加する
               .display_none.select-wrap
                 %i.fa.fa-angle-down
                 %select.k_ir_section__inner--form3-right-select-category#category_grandchildren

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,10 @@ Rails.application.routes.draw do
   resources :imeges, only: [:new, :create]
   resources :mypages, only: [:index,:update]
 
-  get '/set_children_category',to: 'categories#set_children_category'
-  get '/set_grandchild_category',to: 'categories#set_grandchild_category'
-  
+  resources :categories do
+    collection do
+      get 'set_children_category'
+      get 'set_grandchild_category'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   resources :imeges, only: [:new, :create]
   resources :mypages, only: [:index,:update]
 
-  resources :categories do
+  resources :categories, only:[:new] do
     collection do
       get 'set_children_category'
       get 'set_grandchild_category'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,8 @@ Rails.application.routes.draw do
   resources :cards, only: [:index, :create, :new, :destroy]
   resources :imeges, only: [:new, :create]
   resources :mypages, only: [:index,:update]
+
+  get '/set_children_category',to: 'categories#set_children_category'
+  get '/set_grandchild_category',to: 'categories#set_grandchild_category'
+  
 end


### PR DESCRIPTION
# what
・商品出品画面のカテゴリのselectボックスを実装した（遷移は以下）
1. 親カテゴリのみ表示
2. 親カテゴリ選択時に小カテゴリを追加表示
3. 子カテゴリ選択時に孫カテゴリを追加表示

# why
・必須要件のため
