### PR TITLE
add-トップページの表示画像リンクの変更

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,10 @@ class ItemsController < ApplicationController
   require 'payjp'
 
   def index
-    @items = Item.last(10)
+    @ladies_items = Item.where(category: 160..339).last(10)
+    @mens_items = Item.where(category: 340..470).last(10)
+    @electronics_items = Item.where(category: 955..1029).last(10)
+    @toys_items = Item.where(category: 766..866).last(10)
     delete_session
   end
 

--- a/app/views/items/_NewArrivalItems.html.haml
+++ b/app/views/items/_NewArrivalItems.html.haml
@@ -23,8 +23,8 @@
           =link_to "", id:"",class: "more" do
             もっと見る >
     .item-images
-      - if @items
-        - @items.reverse.each do |item|
+      - if @ladies_items
+        - @ladies_items.reverse.each do |item|
           =link_to item_path(item.id), class: "item-images__link" do
             .item-images__link__contents
               .item-images__link__contents__container
@@ -42,8 +42,8 @@
           =link_to "", id:"",class: "more" do
             もっと見る >
     .item-images
-      - if @items
-        - @items.reverse.each do |item|
+      - if @mens_items
+        - @mens_items.reverse.each do |item|
           =link_to item_path(item.id), class: "item-images__link" do
             .item-images__link__contents
               .item-images__link__contents__container
@@ -61,8 +61,8 @@
           =link_to "", id:"",class: "more" do
             もっと見る >
     .item-images
-      - if @items
-        - @items.reverse.each do |item|
+      - if @electronics_items
+        - @electronics_items.reverse.each do |item|
           =link_to item_path(item.id), class: "item-images__link" do
             .item-images__link__contents
               .item-images__link__contents__container
@@ -80,8 +80,8 @@
           =link_to "", id:"",class: "more" do
             もっと見る >
     .item-images
-      - if @items
-        - @items.reverse.each do |item|
+      - if @toys_items
+        - @toys_items.reverse.each do |item|
           =link_to item_path(item.id), class: "item-images__link" do
             .item-images__link__contents
               .item-images__link__contents__container

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -10,14 +10,15 @@
                                             new_arrival2:"メンズ新着アイテム",
                                             new_arrival3:"家電・スマホ・カメラ新着アイテム",
                                             new_arrival4:"おもちゃ・ホビー・グッズ新着アイテム"}
-  = render partial: "NewArrivalItems", locals: {category:"人気のブランド",
-                                            name1:"シャネル",
-                                            name2:"ルイヴィトン",
-                                            name3:"シュプリーム",
-                                            name4:"ナイキ",
-                                            new_arrival1:"シャネル新着アイテム",
-                                            new_arrival2:"ルイヴィトン新着アイテム",
-                                            new_arrival3:"シュプリーム新着アイテム",
-                                            new_arrival4:"ナイキ新着アイテム"}
+  -# 以降の記述はブランドの定義完了次第実装（ブランドの新着アイテムを記述）
+  -# = render partial: "NewArrivalItems", locals: {category:"人気のブランド",
+  -#                                           name1:"シャネル",
+  -#                                           name2:"ルイヴィトン",
+  -#                                           name3:"シュプリーム",
+  -#                                           name4:"ナイキ",
+  -#                                           new_arrival1:"シャネル新着アイテム",
+  -#                                           new_arrival2:"ルイヴィトン新着アイテム",
+  -#                                           new_arrival3:"シュプリーム新着アイテム",
+  -#                                           new_arrival4:"ナイキ新着アイテム"}
 = render "./shared/footer"
 = render "./shared/sell-btn"


### PR DESCRIPTION
# what
・トップページに表示されるカテゴリー毎の新着商品を、最適化（抽出条件を「商品すべて」からそれぞれのカテゴリーに紐づく商品に変更した）
・ブランドの表示に関してはコメントアウト（今後実装することを鑑みて削除ではなくコメントアウトした）

# why
・必須要件のため
・ブランドは現段階では未定義のため