### PR TITLE
[サーバーサイド]商品編集機能 (商品画像追加・削除)

### DIFF
--- a/app/assets/javascripts/upload_image.js
+++ b/app/assets/javascripts/upload_image.js
@@ -6,11 +6,15 @@ $(function() {
   var inputs  =[];
   var input_area = $('.input_area');
   var preview = $('#preview');
+  // 追加する画像にデータ属性を加える際に使用 0スタートで数値を減少させない(削除時の不具合対策)
   var imageId = 0;
+  // 既に登録してある画像数
   var editImageId = 0;
+  // 既に登録してある画像を削除する場合のフラグ管理用、配列で管理（0:削除, 1:変更なし）
   var updateImageIdArray = [];
 
-  // 
+
+  // 画像追加時の処理
   $(document).on('change', 'input[type= "file"].upload-image',function(event){
     var file = $(this).prop('files')[0];
     var reader = new FileReader();
@@ -23,7 +27,7 @@ $(function() {
       })
     }
     reader.readAsDataURL(file);
-    
+
     img.attr('data-image', imageId);
     preview.append(img);
     images.push(img);
@@ -45,67 +49,42 @@ $(function() {
 
   // プレビュー画像の削除ボタン押下時
   $(document).on('click', '.delete-btn', function() {
-    var target_image = $(this).parent().parent();
-    var deleteImageId = target_image.data('image')
+    // 削除ボタンする画像のカスタムデータの番号
+    var deleteImageId = $(this).parent().parent().data('image');
+    // 削除ボタンを押した画像をプレービューから消す
+    $(`[data-image="${deleteImageId}"]`).remove();
 
-    var target_image1 = $(`[data-image="${deleteImageId}"]`)
-    target_image1.remove();
-
+    // 配列imagesから削除画像のデータを消すために変数を設定
     var splitImageNo = null;
     $.each(images, function(index, element){
       if(element.data('image') == deleteImageId){
         splitImageNo = index
       }
-    })
+    });
+    // 配列imagesから削除する画像データを削除
     images.splice(splitImageNo, 1);
 
+    // 配列inputsから削除画像のデータを消すために変数を設定
     var splitinputNo = null;
     $.each(inputs, function(index, element){
       if(element.data('image') == deleteImageId){
         splitinputNo = index
       }
-    })
+    });
+    // 配列inputsから削除する画像データを削除
     inputs.splice(splitinputNo, 1);
 
+    // 削除ボタンが押されたのが既存の登録画像の場合の処理、削除フラグを追加
     if(deleteImageId <= (editImageId - 1)){
       updateImageIdArray[deleteImageId] = 0
 
-      // var update = $(`<div class="upload-image-array", data-image-array= [${updateImageIdArray}], name="item[images_attributes][${imageId}][image]"></div>`);
+      // コントローラ側で処理しやすいように配列を結合する
       var updateImageId = updateImageIdArray.join("");
-      console.log(updateImageId)
+      // paramsにデータを送るためにhidden属性でデータを付与
       var update = $(`<input type="hidden" class="upload-image-array" name="item-image-array" id="item-image-array" value="${updateImageId}">`)
       $(".upload-image-array").remove()
       $(".input_area").prepend(update)
     }
-
-
-    // $.each(inputs, function(index, input){
-    //   console.log($(this))
-    //   console.log(index)
-    //   console.log(target_image.data('image'))
-    //   if ($(this).data('image') == target_image.data('image')){
-    //     $(this).remove();
-    //     target_image.remove();
-    //     var num = $(this).data('image');
-    //     images.splice(num, 1);
-    //     inputs.splice(num, 1);
-    //     if(inputs.length == 0) {
-    //       $('input[type= "file"].upload-image').attr({
-    //         'data-image': 0
-    //       })
-    //     }
-    //   }
-    // })
-    // $('input[type= "file"].upload-image:first').attr({
-    //   'data-image': imageId
-    // })
-    // $.each(inputs, function(index, input) {
-    //   var input = $(this)
-    //   input.attr({
-    //     'data-image': imageId
-    //   })
-    //   $('input[type= "file"].upload-image:first').after(input)
-    // })
     dropzone.css({
       'display': 'block'
     })
@@ -114,12 +93,17 @@ $(function() {
     })
   })
 
+
+  // 商品編集画面を開いた時の処理。既に登録されている画像が削除される場合の準備を行う
   $(document).ready(function(){
     var itemImages = $('.img_view')
     itemImages.each(function(index, element){
       images.push($(element));
+      // 既に登録してある画像の数だけ「1」を配列に加える(この1が0になった画像を削除する)
       updateImageIdArray.push(1)
+      // 既に登録してある画像数を数える
       editImageId += 1;
+      // 商品編集画面を開いた段階ではeditImageIdと同じ
       imageId += 1;
     })
     var new_image = $(`<input id="upload-image__btn" class="upload-image" data-image= ${images.length} type="file" name="item[images_attributes][${images.length}][image]">`);

--- a/app/assets/javascripts/upload_image.js
+++ b/app/assets/javascripts/upload_image.js
@@ -6,6 +6,9 @@ $(function() {
   var inputs  =[];
   var input_area = $('.input_area');
   var preview = $('#preview');
+  var imageId = 0;
+  var editImageId = 0;
+  var updateImageIdArray = [];
 
   // 
   $(document).on('change', 'input[type= "file"].upload-image',function(event){
@@ -20,20 +23,20 @@ $(function() {
       })
     }
     reader.readAsDataURL(file);
+    
+    img.attr('data-image', imageId);
+    preview.append(img);
     images.push(img);
-        $('#preview').empty();
-        $.each(images, function(index, image) {
-          image.attr('data-image', index);
-          preview.append(image);
-        })
-        dropzone.css({
-          'width': `calc(100% - (124px * ${images.length}))`
-        })
-      if(images.length == 5) {
-        $(".dropzone-area").attr('id', 'nothing');
-      }
+    imageId += 1;
+    dropzone.css({
+      'width': `calc(100% - (124px * ${images.length}))`
+    })
+
+    if(images.length == 5) {
+      $(".dropzone-area").attr('id', 'nothing');
+    }
     // 新しいインプットの表示
-    var new_image = $(`<input id="upload-image__btn" class="upload-image" data-image= ${images.length} type="file" name="item[images_attributes][${images.length}][image]">`);
+    var new_image = $(`<input id="upload-image__btn" class="upload-image" data-image= ${imageId} type="file" name="item[images_attributes][${imageId}][image]">`);
     input_area.prepend(new_image);
   });
 
@@ -43,40 +46,90 @@ $(function() {
   // プレビュー画像の削除ボタン押下時
   $(document).on('click', '.delete-btn', function() {
     var target_image = $(this).parent().parent();
-    $.each(inputs, function(index, input){
-      if ($(this).data('image') == target_image.data('image')){
-        $(this).remove();
-        target_image.remove();
-        var num = $(this).data('image');
-        images.splice(num, 1);
-        inputs.splice(num, 1);
-        if(inputs.length == 0) {
-          $('input[type= "file"].upload-image').attr({
-            'data-image': 0
-          })
-        }
+    var deleteImageId = target_image.data('image')
+
+    var target_image1 = $(`[data-image="${deleteImageId}"]`)
+    target_image1.remove();
+
+    var splitImageNo = null;
+    $.each(images, function(index, element){
+      if(element.data('image') == deleteImageId){
+        splitImageNo = index
       }
     })
-    $('input[type= "file"].upload-image:first').attr({
-      'data-image': inputs.length
+    images.splice(splitImageNo, 1);
+
+    var splitinputNo = null;
+    $.each(inputs, function(index, element){
+      if(element.data('image') == deleteImageId){
+        splitinputNo = index
+      }
     })
-    $.each(inputs, function(index, input) {
-      var input = $(this)
-      input.attr({
-        'data-image': index
-      })
-      $('input[type= "file"].upload-image:first').after(input)
+    inputs.splice(splitinputNo, 1);
+
+    if(deleteImageId <= (editImageId - 1)){
+      updateImageIdArray[deleteImageId] = 0
+
+      // var update = $(`<div class="upload-image-array", data-image-array= [${updateImageIdArray}], name="item[images_attributes][${imageId}][image]"></div>`);
+      var updateImageId = updateImageIdArray.join("");
+      console.log(updateImageId)
+      var update = $(`<input type="hidden" class="upload-image-array" name="item-image-array" id="item-image-array" value="${updateImageId}">`)
+      $(".upload-image-array").remove()
+      $(".input_area").prepend(update)
+    }
+
+
+    // $.each(inputs, function(index, input){
+    //   console.log($(this))
+    //   console.log(index)
+    //   console.log(target_image.data('image'))
+    //   if ($(this).data('image') == target_image.data('image')){
+    //     $(this).remove();
+    //     target_image.remove();
+    //     var num = $(this).data('image');
+    //     images.splice(num, 1);
+    //     inputs.splice(num, 1);
+    //     if(inputs.length == 0) {
+    //       $('input[type= "file"].upload-image').attr({
+    //         'data-image': 0
+    //       })
+    //     }
+    //   }
+    // })
+    // $('input[type= "file"].upload-image:first').attr({
+    //   'data-image': imageId
+    // })
+    // $.each(inputs, function(index, input) {
+    //   var input = $(this)
+    //   input.attr({
+    //     'data-image': imageId
+    //   })
+    //   $('input[type= "file"].upload-image:first').after(input)
+    // })
+    dropzone.css({
+      'display': 'block'
     })
-      dropzone.css({
-        'display': 'block'
-      })
-      $.each(images, function(index, image) {
-        image.attr('data-image', index);
-        preview.append(image);
-      })
-      dropzone.css({
-        'width': `calc(100% - (124px * ${images.length}))`
-      })
+    dropzone.css({
+      'width': `calc(100% - (124px * ${images.length}))`
+    })
   })
 
+  $(document).ready(function(){
+    var itemImages = $('.img_view')
+    itemImages.each(function(index, element){
+      images.push($(element));
+      updateImageIdArray.push(1)
+      editImageId += 1;
+      imageId += 1;
+    })
+    var new_image = $(`<input id="upload-image__btn" class="upload-image" data-image= ${images.length} type="file" name="item[images_attributes][${images.length}][image]">`);
+    $("#upload-image__btn").remove();
+    input_area.prepend(new_image);
+    dropzone.css({
+      'display': 'block'
+    })
+    dropzone.css({
+      'width': `calc(100% - (124px * ${images.length}))`
+    })
+  })
 })

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,18 +52,18 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @itemimages = @item.itemimages
-    itemimage_count = @itemimages.count
+    @item_images = @item.itemimages
+    item_image_count = @item_images.count
 
     # 商品編集により画像が0以下になる場合、編集ページに戻る
-    if itemimage_count + count_add_itemimage - count_delete_itemimage <= 0
+    if item_image_count + count_add_item_image - count_delete_item_image <= 0
       redirect_to edit_item_path(@item.id)
     else
       if @item.update(item_params)
         # 削除する画像がある場合、その画像を削除する
-        if choose_itemimage_destroy
-          choose_itemimage_destroy.each_with_index do |itemimage, index|
-            @itemimages[index].destroy if itemimage == 0
+        if choose_item_image_destroy
+          choose_item_image_destroy.each_with_index do |item_image, index|
+            @item_images[index].destroy if item_image == 0
           end
         end
         # 新しく追加された画像がある場合、その画像を保存する
@@ -186,18 +186,18 @@ class ItemsController < ApplicationController
     session[:request_from] = request.original_url
   end
 
-  def choose_itemimage_destroy
+  def choose_item_image_destroy
     params.require(:"item-image-array").split("").map{|item| item.to_i} if params[:"item-image-array"]
   end
 
   # 商品編集で追加する画像数
-  def count_add_itemimage
+  def count_add_item_image
     params.require(:item)[:images_attributes] ? image_params.to_unsafe_h.length : 0
   end
 
   # 商品編集で削除する画像数
-  def count_delete_itemimage
-    params[:"item-image-array"] ? choose_itemimage_destroy.count(0) : 0
+  def count_delete_item_image
+    params[:"item-image-array"] ? choose_item_image_destroy.count(0) : 0
   end
 end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only:[:new, :create, :destroy, :edit, :update, :buy, :pay]
-  before_action :get_item, only: [:show, :buy, :pay, :destroy]
+  before_action :get_item, only: [:show, :buy, :pay, :destroy, :edit, :update]
   before_action :set_request_from, only: [:buy]
   before_action :set_card, only: [:buy, :pay]
 
@@ -46,18 +46,36 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
     @parent_category        = Category.where(ancestry: nil)
     @children_category      = @item.category.parent.parent.children
     @grandchildren_category = @item.category.parent.children
   end
 
   def update
-    @item = Item.find(params[:id])
-    if @item.update(item_params)
-      redirect_to item_path(params[:id])
+    @itemimages = @item.itemimages
+    @itemimage_count = @itemimages.count
+
+    # 商品編集により画像が0以下になる場合、編集ページに戻る
+    if @itemimage_count + count_add_itemimage - count_delete_itemimage <= 0
+      redirect_to edit_item_path(@item.id)
     else
-      redirect_to root_path
+      if @item.update(item_params)
+        # 削除する画像がある場合、その画像を削除する
+        if choose_itemimage_destroy
+          choose_itemimage_destroy.each_with_index do |itemimage, index|
+            @itemimages[index].destroy if itemimage == 0
+          end
+        end
+        # 新しく追加された画像がある場合、その画像を保存する
+        if image_params
+          image_params.to_unsafe_h.reverse_each do |key, value|
+            redirect_to root_path unless Itemimage.create(value.merge(item_id: @item.id))
+          end
+        end
+        redirect_to item_path(@item.id)
+      else
+        redirect_to root_path
+      end
     end
   end
 
@@ -136,7 +154,7 @@ class ItemsController < ApplicationController
   end
 
   def image_params
-    params.require(:item).require(:images_attributes)
+    params.require(:item).require(:images_attributes) if params.require(:item)[:images_attributes]
   end
 
   # ユーザー登録を途中で抜けた場合のsessionを削除
@@ -163,6 +181,20 @@ class ItemsController < ApplicationController
   def set_request_from
     # 現在のURLを保存しておく
     session[:request_from] = request.original_url
+  end
+
+  def choose_itemimage_destroy
+    params.require(:"item-image-array").split("").map{|item| item.to_i} if params[:"item-image-array"]
+  end
+
+  # 商品編集で追加する画像数
+  def count_add_itemimage
+    params.require(:item)[:images_attributes] ? image_params.to_unsafe_h.length : 0
+  end
+
+  # 商品編集で削除する画像数
+  def count_delete_itemimage
+    params[:"item-image-array"] ? choose_itemimage_destroy.count(0) : 0
   end
 end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,10 +53,10 @@ class ItemsController < ApplicationController
 
   def update
     @itemimages = @item.itemimages
-    @itemimage_count = @itemimages.count
+    itemimage_count = @itemimages.count
 
     # 商品編集により画像が0以下になる場合、編集ページに戻る
-    if @itemimage_count + count_add_itemimage - count_delete_itemimage <= 0
+    if itemimage_count + count_add_itemimage - count_delete_itemimage <= 0
       redirect_to edit_item_path(@item.id)
     else
       if @item.update(item_params)
@@ -69,11 +69,14 @@ class ItemsController < ApplicationController
         # 新しく追加された画像がある場合、その画像を保存する
         if image_params
           image_params.to_unsafe_h.reverse_each do |key, value|
+            # 保存に失敗する、画像の保存に失敗したらトップページに移動
             redirect_to root_path unless Itemimage.create(value.merge(item_id: @item.id))
           end
         end
+        # 全部完了したら商品詳細ページに移動
         redirect_to item_path(@item.id)
       else
+        # 商品の更新に失敗したらトップページに移動
         redirect_to root_path
       end
     end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -17,10 +17,17 @@
             = f.fields_for :image do |image|
               .dropzone-container
                 #preview
+                  - @item.itemimages.each_with_index do |itemimage, i|
+                    %div{class: "img_view", data: {image: i}}
+                      = image_tag itemimage.image.url, name: "item[images_attributes][#{i}][image]"
+                      .upload-image__prev--btn
+                        .edit-btn 編集
+                        .delete-btn 削除
                 .dropzone-area
                   = image.label :image, class: "dropzone-box", for: "upload-image__btn" do
                     .input_area
-                      = image.file_field :image, id: "upload-image__btn", class: "upload-image", 'data-image': 0, type: "file", name: "item[images_attributes][0][image]"
+                      - @item.itemimages.each_with_index do |itemimage, i|
+                        = image.file_field :image, id: "upload-image__btn__#{i}", class: "upload-image", 'data-image': i, type: "file", name: "item[images_attributes][#{i}][image]"
                       %p
                         ドラッグアンドドロップ
                         %br


### PR DESCRIPTION
# What
- 既に保存されている商品画像の表示
- 商品画像の追加・削除機能実装
- 既存jsファイルを編集
  カスタムデータで付与する番号を通し番号に変更(削除時の不具合対応のため)
# Why
商品編集で商品画像の追加・削除を行う

***
- 商品画像追加
![商品編集画像追加](https://user-images.githubusercontent.com/57243991/71339266-56cfc300-2596-11ea-9af2-2bc9685b48ac.gif)

- 商品画像削除
![商品編集画像削除](https://user-images.githubusercontent.com/57243991/71339270-5d5e3a80-2596-11ea-9a06-27da2b62ba69.gif)
